### PR TITLE
mangrove.js: Move exported types from Market.ts to types/index.ts

### DIFF
--- a/packages/cleaning-bot/src/MarketCleaner.ts
+++ b/packages/cleaning-bot/src/MarketCleaner.ts
@@ -1,5 +1,6 @@
 import { logger } from "./util/logger";
-import { Market, Offer } from "@giry/mangrove-js/dist/nodejs/market";
+import { Market } from "@giry/mangrove-js/dist/nodejs/market";
+import { Offer } from "@giry/mangrove-js/dist/nodejs/types";
 import { MgvToken } from "@giry/mangrove-js/dist/nodejs/mgvtoken";
 import { Provider } from "@ethersproject/providers";
 import { BigNumber, BigNumberish } from "ethers";

--- a/packages/mangrove.js/src/mangrove.ts
+++ b/packages/mangrove.js/src/mangrove.ts
@@ -1,6 +1,6 @@
 import { addresses, decimals as loadedDecimals } from "./constants";
 import * as eth from "./eth";
-import { BookOptions, Market } from "./market";
+import { Market } from "./market";
 import {
   Provider,
   Signer,
@@ -8,6 +8,7 @@ import {
   Bigish,
   globalConfig,
   CreateSignerOptions,
+  BookOptions,
 } from "./types";
 import * as typechain from "./types/typechain";
 import { MgvToken } from "./mgvtoken";

--- a/packages/mangrove.js/src/market.ts
+++ b/packages/mangrove.js/src/market.ts
@@ -2,11 +2,13 @@ import * as ethers from "ethers";
 import { BigNumber } from "ethers"; // syntactic sugar
 import {
   TradeParams,
+  BookOptions,
   BookReturns,
   Bigish,
   rawConfig,
   localConfig,
   bookSubscriptionEvent,
+  Offer,
 } from "./types";
 import { Mangrove } from "./mangrove";
 import { MgvToken } from "./mgvtoken";
@@ -27,12 +29,6 @@ Big.DP = 20; // precision when dividing
 Big.RM = Big.roundHalfUp; // round to nearest
 
 type OrderResult = { got: Big; gave: Big };
-export type BookOptions = {
-  fromId?: number;
-  maxOffers?: number;
-  chunkSize?: number;
-  blockNumber?: number;
-};
 const bookOptsDefault: BookOptions = {
   fromId: 0,
   maxOffers: DEFAULT_MAX_OFFERS,
@@ -43,21 +39,6 @@ type offerList = { offers: Map<number, Offer>; best: number };
 type semibook = offerList & {
   ba: "bids" | "asks";
   gasbase: { offer_gasbase: number; overhead_gasbase: number };
-};
-
-export type Offer = {
-  id: number;
-  prev: number;
-  next: number;
-  gasprice: number;
-  maker: string;
-  gasreq: number;
-  overhead_gasbase: number;
-  offer_gasbase: number;
-  wants: Big;
-  gives: Big;
-  volume: Big;
-  price: Big;
 };
 
 type OfferData = {

--- a/packages/mangrove.js/src/types/index.ts
+++ b/packages/mangrove.js/src/types/index.ts
@@ -47,6 +47,8 @@ export type globalConfig = {
   dead: boolean;
 };
 
+// =-=-=-=-=-= /src/market.ts =-=-=-=-=-=
+
 export type bookSubscriptionEvent =
   | ({ name: "OfferWrite" } & MgvTypes.OfferWriteEvent)
   | ({ name: "OfferFail" } & MgvTypes.OfferFailEvent)
@@ -54,18 +56,26 @@ export type bookSubscriptionEvent =
   | ({ name: "OfferRetract" } & MgvTypes.OfferRetractEvent)
   | ({ name: "SetGasbase" } & MgvTypes.SetGasbaseEvent);
 
+export type BookOptions = {
+  fromId?: number;
+  maxOffers?: number;
+  chunkSize?: number;
+  blockNumber?: number;
+};
+
 export type Offer = {
+  id: number;
   prev: number;
   next: number;
-  volume: Big;
-  price: Big;
-  gives: Big;
-  wants: Big;
-  overhead_gasbase: number;
-  offer_gasbase: number;
+  gasprice: number;
   maker: string;
   gasreq: number;
-  gasprice: number;
+  overhead_gasbase: number;
+  offer_gasbase: number;
+  wants: Big;
+  gives: Big;
+  volume: Big;
+  price: Big;
 };
 
 // =-=-=-=-=-= /src/index.ts =-=-=-=-=-=

--- a/packages/obfiller-bot/src/OfferMaker.ts
+++ b/packages/obfiller-bot/src/OfferMaker.ts
@@ -1,6 +1,7 @@
 import { logger } from "./util/logger";
 import { sleep } from "@giry/commonlib-js";
-import { Market, Offer } from "@giry/mangrove-js/dist/nodejs/market";
+import { Market } from "@giry/mangrove-js/dist/nodejs/market";
+import { Offer } from "@giry/mangrove-js/dist/nodejs/types";
 import { MgvToken } from "@giry/mangrove-js/dist/nodejs/mgvtoken";
 import { Provider } from "@ethersproject/providers";
 import { BigNumberish } from "ethers";

--- a/packages/obfiller-bot/src/OfferTaker.ts
+++ b/packages/obfiller-bot/src/OfferTaker.ts
@@ -1,6 +1,7 @@
 import { logger } from "./util/logger";
 import { sleep } from "@giry/commonlib-js";
-import { Market, Offer } from "@giry/mangrove-js/dist/nodejs/market";
+import { Market } from "@giry/mangrove-js/dist/nodejs/market";
+import { Offer } from "@giry/mangrove-js/dist/nodejs/types";
 import { MgvToken } from "@giry/mangrove-js/dist/nodejs/mgvtoken";
 import { Provider } from "@ethersproject/providers";
 import { BigNumberish } from "ethers";


### PR DESCRIPTION
The Offer type was declared both places, but in slightly different ways.