### PR TITLE
mangrove.js: Compile TypeScript to ES2015 instead of ES2020

### DIFF
--- a/packages/mangrove.js/tsconfig.json
+++ b/packages/mangrove.js/tsconfig.json
@@ -9,7 +9,7 @@
     "sourceMap": true,
     "declaration": true,
     "noErrorTruncation": true,
-    "target": "es2020",
+    "target": "es2015",
     "incremental":true
     //"strict": true,
     //"suppressImplicitAnyIndexErrors": true,


### PR DESCRIPTION
Webpack 4 cannot handle optional chaining (?.) introduced in ECMA Script 2020. So to avoid issues with Webpack, we target ES2015 instead.