### PR TITLE
Fix CI for external PR's and introduce security guard job

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -6,18 +6,64 @@ on:
     branches: [ master, feature/**, issue/**, dev-solidity, dev ]
     paths-ignore: 
       - '**.md'
-  pull_request:
+  pull_request_target:
     branches: [ master ]
+    types: [opened, synchronize, reopened, labeled]
     paths-ignore: 
       - '**.md'
 
 env:
   NODE_ENV: test
   working-directory: packages/mangrove-solidity
+  # Ternary-esque expression hack: The first two lines are the condition,
+  # the 3rd line is the value if `true`, the 4th line is the value if `false`.
+  GIT_REF_TO_TEST: >
+                   ${{  (   (   github.event_name != 'pull_request_target'
+                             || github.event.pull_request.head.repo.full_name == github.repository)
+                         && github.ref )
+                      || format('refs/pull/{0}/merge', github.event.number) }}
 
 jobs:
+  # ==== Job: Security guard ====
+  # The security guard job only allows workflows triggered by external PR's to continue
+  # if they are labelled 'safe to test'.
+  security-guard:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Comment external PR's with first time (before being labelled 'external PR')
+      if: >
+          !(   github.event_name != 'pull_request_target'
+            || github.event.pull_request.head.repo.full_name == github.repository
+            || contains(github.event.pull_request.labels.*.name, 'external PR') )
+      uses: peter-evans/create-or-update-comment@v1
+      with:
+        issue-number: ${{ github.event.pull_request.number }}
+        body: >
+              Pull requests from forks must be reviewed before build and tests are run.
+              A maintainer will review and add the 'safe to test' label if everything looks good.
+
+    - name: Label external PR's with 'external PR'
+      if: >
+          !(   github.event_name != 'pull_request_target'
+            || github.event.pull_request.head.repo.full_name == github.repository
+            || contains(github.event.pull_request.labels.*.name, 'external PR') )
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        labels: external PR
+
+    - name: Fail if workflow triggered by external PR *not* labelled 'safe to test'
+      if: >
+          !(   github.event_name != 'pull_request_target'
+            || github.event.pull_request.head.repo.full_name == github.repository
+            || contains(github.event.pull_request.labels.*.name, 'safe to test') )
+      uses: andymckay/cancel-action@0.2
+  # ==== End job: Security guard ====
+
   # ==== Job: Build and test commonlib.js ====
   commonlib-js:
+    needs: [security-guard]
+
     runs-on: ubuntu-latest
 
     env:
@@ -91,6 +137,8 @@ jobs:
 
   # ==== Job: Build and test Mangrove Core
   mangrove-solidity:
+    needs: [security-guard]
+
     runs-on: ubuntu-latest
 
     defaults:
@@ -188,13 +236,12 @@ jobs:
       with:
         name: mangrove-solidity-out.zip
         path: mangrove-solidity-out.zip
-
   # ==== End job mangrove-solidity ====
 
   # ==== Job: Build Mangrove documentation ====
   mangrove-solidity-doc:
-    needs: mangrove-solidity
-    
+    needs: [security-guard, mangrove-solidity]
+
     runs-on: ubuntu-latest
 
     defaults:
@@ -234,12 +281,11 @@ jobs:
       with:
         name: documentation
         path: ${{env.working-directory}}/doc/
-
   # ==== End job mangrove-solidity-doc ====
 
   # ==== Job: Build and test hardhat-utils ====
   hardhat-utils:
-    needs: mangrove-solidity
+    needs: [security-guard, mangrove-solidity]
 
     runs-on: ubuntu-latest
 
@@ -326,7 +372,7 @@ jobs:
 
   # ==== Job: Build and test mangrove.js ====
   mangrove-js:
-    needs: [mangrove-solidity, hardhat-utils]
+    needs: [security-guard, mangrove-solidity, hardhat-utils]
 
     runs-on: ubuntu-latest
 
@@ -418,12 +464,11 @@ jobs:
       with:
         name: mangrove-js-out.zip
         path: mangrove-js-out.zip
-
   # ==== End job: mangrove.js ====
         
   # ==== Job: Build and test cleaning-bot ====
   cleaning-bot:
-    needs: [commonlib-js, mangrove-solidity, hardhat-utils, mangrove-js]
+    needs: [security-guard, commonlib-js, mangrove-solidity, hardhat-utils, mangrove-js]
 
     runs-on: ubuntu-latest
 
@@ -524,12 +569,11 @@ jobs:
         name: Cleaning Bot - Tests                   # Name of the check run which will be created
         path: packages/cleaning-bot/integration-tests-report.json # Path to test results
         reporter: mocha-json                               # Format of test results
-
   # ==== End job: cleaning-bot ====        
 
   # ==== Job: Build and test updategas-bot ====
   updategas-bot:
-    needs: [commonlib-js, mangrove-solidity, hardhat-utils, mangrove-js]
+    needs: [security-guard, commonlib-js, mangrove-solidity, hardhat-utils, mangrove-js]
 
     runs-on: ubuntu-latest
 
@@ -630,12 +674,11 @@ jobs:
         name: Update Gas Bot - Tests                   # Name of the check run which will be created
         path: packages/updategas-bot/integration-tests-report.json # Path to test results
         reporter: mocha-json                               # Format of test results
-
   # ==== End job: updategas-bot ====
           
   # ==== Job: Build and test obfiller-bot ====
   obfiller-bot:
-    needs: [commonlib-js, mangrove-solidity, hardhat-utils, mangrove-js]
+    needs: [security-guard, commonlib-js, mangrove-solidity, hardhat-utils, mangrove-js]
 
     runs-on: ubuntu-latest
 
@@ -736,13 +779,11 @@ jobs:
         name: Order Book Filler Bot - Tests                   # Name of the check run which will be created
         path: packages/obfiller-bot/integration-tests-report.json # Path to test results
         reporter: mocha-json                               # Format of test results
-
   # ==== End job: obfiller-bot ====        
-
 
   # ==== Job: Build and test template-bot ====
   template-bot:
-    needs: [commonlib-js, mangrove-solidity, hardhat-utils, mangrove-js]
+    needs: [security-guard, commonlib-js, mangrove-solidity, hardhat-utils, mangrove-js]
 
     runs-on: ubuntu-latest
 
@@ -843,5 +884,4 @@ jobs:
         name: Template Bot - Tests                   # Name of the check run which will be created
         path: packages/template-bot/integration-tests-report.json # Path to test results
         reporter: mocha-json                               # Format of test results
-
   # ==== End job: template-bot ====


### PR DESCRIPTION
Mangrove's git repos are public and anyone can make pull requests (PR's). Such PR's can contain arbitrary code, both regular code and workflow definitions. A malicious actor could therefore potentially use a PR to abuse our CI setup, e.g. by using compute/storage resources or leaking secrets.

Our CI setup must therefore treat external PR's with great care to avoid abuse.

GitHub Actions unfortunately does not provide a good framework or best practices for CI of external PR's in a secure manner. Our solution is therefore somewhat bespoke and clunky, but we deem it good enough and secure enough for now.

In overview, our approach is the following:

- Our workflow begin with a "guard" job which only allows the workflow to continue if the trigger is internal or an external PR that has been labelled `safe to test`.
- All other jobs depend on the "guard" job and thus only run if the guard job allows them to.
- On the first workflow run, external PR's are automatically labelled `external PR` and a comment is added which explains that CI is waiting for a maintainer to label the PR `safe to test`.

The pros and cons of this approach are:

- Pros
    - We can use on workflow definition for both internally and externally triggered workflows
    - The implementation effort is minimal
- Cons
    - External PR's will see some cancelled workflows
        - It would be better if CI simply didn't run on external PR's before they had been labelled `safe to test`. But to our knowledge, this is not currently possible.
    - Maintainers must manually review and label external PR's before any CI executes.