### PR TITLE
CI: Fail CI for external PR's not labelled 'safe to test'

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -41,6 +41,7 @@ jobs:
         issue-number: ${{ github.event.pull_request.number }}
         body: >
               Pull requests from forks must be reviewed before build and tests are run.
+
               A maintainer will review and add the 'safe to test' label if everything looks good.
 
     - name: Label external PR's with 'external PR'
@@ -57,7 +58,9 @@ jobs:
           !(   github.event_name != 'pull_request_target'
             || github.event.pull_request.head.repo.full_name == github.repository
             || contains(github.event.pull_request.labels.*.name, 'safe to test') )
-      uses: andymckay/cancel-action@0.2
+      uses: actions/github-script@v3
+      with:
+        script: core.setFailed('External PR must be marked \'safe to test\' for CI to run')
   # ==== End job: Security guard ====
 
   # ==== Job: Build and test commonlib.js ====


### PR DESCRIPTION
Previously, the workflow was only cancelled. This caused the UI to signal that the PR was ready to merge though it hadn't been build or testet.
Failure is a bit draconian, but safer.